### PR TITLE
Feat: 기초 엔티티 설계

### DIFF
--- a/src/main/java/com/toj/TojApplication.java
+++ b/src/main/java/com/toj/TojApplication.java
@@ -1,13 +1,23 @@
 package com.toj;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class TojApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(TojApplication.class, args);
+    }
+
+    @Bean
+    JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
     }
 
 }

--- a/src/main/java/com/toj/entity/Daily.java
+++ b/src/main/java/com/toj/entity/Daily.java
@@ -1,0 +1,32 @@
+package com.toj.entity;
+
+import com.toj.entity.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Daily extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "daily_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "record_id")
+    private Record record;
+
+    @Enumerated(EnumType.STRING)
+    private DailyCate dailyCate;
+
+    private int score;
+
+    private String status;
+
+    private String failReason;
+
+}

--- a/src/main/java/com/toj/entity/DailyCate.java
+++ b/src/main/java/com/toj/entity/DailyCate.java
@@ -1,0 +1,16 @@
+package com.toj.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum DailyCate {
+
+    SUCCESS("시작할게요", 10),
+    DELAY("잠시 미룰게요", 10),
+    FAIL("오늘은 어려워요", 3);
+
+    private final String value;
+    private final int score;
+}

--- a/src/main/java/com/toj/entity/Record.java
+++ b/src/main/java/com/toj/entity/Record.java
@@ -1,0 +1,35 @@
+package com.toj.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Record {
+
+    @Id
+    @Column(name = "record_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    private RecordCate recordCate;
+
+    private String content;
+
+    private LocalDateTime startDate;
+
+    private LocalDateTime endDate;
+
+    private String alarmTime;
+
+}

--- a/src/main/java/com/toj/entity/RecordCate.java
+++ b/src/main/java/com/toj/entity/RecordCate.java
@@ -1,0 +1,16 @@
+package com.toj.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum RecordCate {
+
+    EXERCISE("운동"),
+    READING("독서"),
+    DEVELOPMENT("자기개발");
+
+    private final String value;
+
+}

--- a/src/main/java/com/toj/entity/common/BaseTimeEntity.java
+++ b/src/main/java/com/toj/entity/common/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.toj.entity.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime regTime;
+
+    @LastModifiedDate
+    private LocalDateTime updateTime;
+}


### PR DESCRIPTION
## 💡 **개요**
- 디자인 피그마, 기획안을 바탕으로 기초 entity 설계, 추후 수정 가능성 농후.
## 📑 **작업 사항**
- daily entity 추가
- daily cate (enum) 추가
- record entity 추가
- record cate (enum)  추가
- 공통으로 쓰일 baseTimeEntity 추가
